### PR TITLE
Fix monoexonic transcripts filtering

### DIFF
--- a/bin/filter_rare_transcripts.py
+++ b/bin/filter_rare_transcripts.py
@@ -156,11 +156,15 @@ mono = transcripts[transcripts['splicing'].isna()][
   ['chromosome', 'strand', 'start', 'end']
 )
 
-mono['group'] = (
-  (mono['chromosome'] != mono['chromosome'].shift()) |
-  (mono['strand'] != mono['strand'].shift()) |
-  (mono['start'] > mono['end'].shift())
-).cumsum()
+previous_end_max = mono.set_index(['chromosome', 'strand'])['end'].groupby(
+  ['chromosome', 'strand'],
+  observed = True
+).shift().groupby(
+  ['chromosome', 'strand'],
+  observed = True
+).cummax().fillna(-1).to_numpy()
+
+mono['group'] = (mono['start'] > previous_end_max).cumsum()
 
 mono = mono.set_index(['chromosome', 'strand', 'group'])
 


### PR DESCRIPTION
When filtering transcripts, monoexonic transcripts that have no overlaps in other annotations are deleted.

To detect overlaps, the algorithm sorts all monoexonic transcripts by chromosome, strand, position, and then compares each transcript's start position to the previous transcript's end position. If transcript n overlaps transcript n-1, it is added to the group, otherwise a new group is created.

An issue with this approach arises when transcript n and n-1 do not overlap yet both overlap transcript n-2.

This PR fixes this issue. The algorithm is modified to compare the transcript's start position to the previous maximum end position. The previous maximum end position is reset when the chromosome changes or the strand changes.

Example:

| chromosome | strand | start | end | previous maximum end | group (before PR) | group (after PR) |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | + | 5 | 9 | -1 | 1 | 1 |
| 1 | + | 10 | 18 | 9 | 2 | 2 |
| 1 | + | 11 | 13 | 18 | 2 | 2 |
| 1 | + | 14 | 20 | 18 | 3 | 2 |
| 1 | + | 15 | 17 | 20 | 3 | 2 |
| 1 | + | 21 | 25 | 20 | 4 | 3 |
| 1 | - | 19 | 24 | -1 | 5 | 4 |
| 1 | - | 22 | 26 | 24 | 5 | 4 |
| 1 | - | 25 | 27 | 26 | 5 | 4 |
| 2 | + | 5 | 9 | -1 | 6 | 5 |
| 2 | + | 10 | 18 | 9 | 7 | 6 |
| 2 | + | 12 | 14 | 18 | 7 | 6 |
| 2 | + | 15 | 19 | 18 | 8 | 6 |
| 2 | + | 20 | 23 | 19 | 9 | 7 |
